### PR TITLE
Add Test Automation Tools and Python 2.7 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 dist/
 *.egg-info/
 *.egg
+.eggs/
 *.py[cod]
 __pycache__/
 *.so
@@ -14,3 +15,6 @@ __pycache__/
 
 # PyCharm
 .idea
+
+# VSCode
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - 3.5
+  - 2.7
+
+# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+install: pip install -U tox-travis
+
+# command to run tests, e.g. python setup.py test
+script: tox

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,11 @@
+pip==8.1.2
+bumpversion==0.5.3
+wheel==0.29.0
+watchdog==0.8.3
+flake8==2.6.0
+tox==2.3.1
+coverage==4.1
+Sphinx==1.4.8
+
+pytest==2.9.2
+pytest-runner==2.11.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,10 @@
 # This flag says that the code is written to work on both Python 2 and Python
 # 3. If at all possible, it is good practice to do this. If you cannot, you
 # will need to generate wheels for each Python version that you support.
-universal=1
+universal = 1
+
+[flake8]
+exclude = docs
+
+[aliases]
+test = pytest

--- a/setup.py
+++ b/setup.py
@@ -81,4 +81,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=['protobuf', 'grpcio'],
 
+    test_suite='tests',
+    tests_require=['pytest'],
+    setup_requires=['pytest-runner'],
 )

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['protobuf', 'grpcio'],
+    install_requires=['protobuf', 'grpcio', 'future>=0.14'],
 
     test_suite='tests',
     tests_require=['pytest'],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+"""Unit test package for pypachy."""

--- a/tests/test_pypachy.py
+++ b/tests/test_pypachy.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for `pypachy` package."""
+
+import pytest
+
+
+import pypachy
+
+
+def test_always_true():
+    assert True == True

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist = py27, py35, flake8
+
+[travis]
+python =
+    3.5: py35
+    2.7: py27
+
+[testenv:flake8]
+basepython=python
+deps=flake8
+commands=flake8 pypachy
+
+[testenv]
+setenv =
+    PYTHONPATH = {toxinidir}
+deps =
+    -r{toxinidir}/requirements_dev.txt
+commands =
+    pip install -U pip
+    py.test --basetemp={envtmpdir}


### PR DESCRIPTION
These commits add pytest, tox, and Travis CI to the project to facilitate the addition of tests.  Currently, the only test is a dummy assertion that is always true.

The future package is required for Python 2.7 tests to pass, so it was added to `setup.py`.